### PR TITLE
[HAL9000-OPS] Updated Python version to 3.9

### DIFF
--- a/.github/workflows/ci-broken.yml
+++ b/.github/workflows/ci-broken.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13.99"
+          python-version: "3.9"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## 🤖 HAL9000-OPS — Surgical Pipeline Fix

> **DRAFT — cannot be merged without manual review.**
> Only the lines directly responsible for the failure were changed.
> All workflow names, job names, step names, and structure are preserved exactly.

---

### What Failed
- **Workflow Run**: #22555510163
- **Branch**: `main`
- **Investigation**: https://github.com/retr0man99/hal9000-ops-target/issues/3

### What Changed
Updated Python version to 3.9

### Exact Diff
```diff
--- a/.github/workflows/ci-broken.yml+++ b/.github/workflows/ci-broken.yml@@ -18,7 +18,7 @@       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13.99"
+          python-version: "3.9"
 
       - name: Install dependencies
         run: |
@@ -46,4 +46,4 @@           context: .
           file: ./Dockerfile
           push: false
-          tags: hal9000-ops-target:${{ github.sha }}+          tags: hal9000-ops-target:${{ github.sha }}

```

### Agent Confidence
`MEDIUM`

### Review Checklist
- [ ] Only the broken lines are changed — nothing else
- [ ] Workflow name, job names, and step names are unchanged
- [ ] The fix addresses the root cause from the investigation issue
- [ ] No secrets or credentials introduced
- [ ] You have verified the fix locally or in a branch run

---
*Generated by [HAL9000-OPS](https://github.com/retr0man99/hal9000-ops) — surgical fixes only*
