### PR TITLE
[HAL9000-OPS] Changed requirementz.txt to requirements.txt on line 19 to f

### DIFF
--- a/.github/workflows/ci-broken.yml
+++ b/.github/workflows/ci-broken.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r app/requirementz.txt
+          pip install -r app/requirements.txt
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## 🤖 HAL9000-OPS — Surgical Pipeline Fix

> **DRAFT — cannot be merged without manual review.**
> Only the lines directly responsible for the failure were changed.
> All workflow names, job names, step names, and structure are preserved exactly.

---

### What Failed
- **Workflow Run**: #22573196985
- **Branch**: `main`
- **Investigation**: https://github.com/retr0man99/hal9000-ops-target/issues/5

### What Changed
Changed requirementz.txt to requirements.txt on line 19 to fix the typo

### Exact Diff
```diff
--- a/.github/workflows/ci-broken.yml+++ b/.github/workflows/ci-broken.yml@@ -22,7 +22,7 @@ 
       - name: Install dependencies
         run: |
-          pip install -r app/requirementz.txt
+          pip install -r app/requirements.txt
 
       - name: Run tests
         run: |
@@ -46,4 +46,4 @@           context: .
           file: ./Dockerfile
           push: false
-          tags: hal9000-ops-target:${{ github.sha }}
+          tags: hal9000-ops-target:${{ github.sha }}
```

### Agent Confidence
`HIGH`

### Review Checklist
- [ ] Only the broken lines are changed — nothing else
- [ ] Workflow name, job names, and step names are unchanged
- [ ] The fix addresses the root cause from the investigation issue
- [ ] No secrets or credentials introduced
- [ ] You have verified the fix locally or in a branch run

---
*Generated by [HAL9000-OPS](https://github.com/retr0man99/hal9000-ops) — surgical fixes only*
