### PR TITLE
[HAL9000-OPS] Changed pip install command to include pytest on line 25 and

### DIFF
--- a/.github/workflows/ci-broken.yml
+++ b/.github/workflows/ci-broken.yml
@@ -22,11 +22,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r app/requirements.txt
+          pip install -r app/requirements.txt && pip install pytest
 
       - name: Run tests
         run: |
-          pytest testss/ -v
+          pytest tests/ -v
 
   docker-build:
     name: Build Docker Image (broken)


### PR DESCRIPTION
## 🤖 HAL9000-OPS — Surgical Pipeline Fix

> **DRAFT — cannot be merged without manual review.**
> Only the lines directly responsible for the failure were changed.
> All workflow names, job names, step names, and structure are preserved exactly.

---

### What Failed
- **Workflow Run**: #22692384113
- **Branch**: `main`
- **Investigation**: https://github.com/retr0man99/hal9000-ops-target/issues/12

### What Changed
Changed pip install command to include pytest on line 25 and corrected test directory on line 29 to fix pytest not found error

### Exact Diff
```diff
--- a/.github/workflows/ci-broken.yml+++ b/.github/workflows/ci-broken.yml@@ -22,11 +22,11 @@ 
       - name: Install dependencies
         run: |
-          pip install -r app/requirements.txt
+          pip install -r app/requirements.txt && pip install pytest
 
       - name: Run tests
         run: |
-          pytest testss/ -v
+          pytest tests/ -v
 
   docker-build:
     name: Build Docker Image (broken)

```

### Agent Confidence
`HIGH`

### Review Checklist
- [ ] Only the broken lines are changed — nothing else
- [ ] Workflow name, job names, and step names are unchanged
- [ ] The fix addresses the root cause from the investigation issue
- [ ] No secrets or credentials introduced
- [ ] You have verified the fix locally or in a branch run

---
*Generated by [HAL9000-OPS](https://github.com/retr0man99/hal9000-ops) — surgical fixes only*
