### PR TITLE
[HAL9000-OPS] Changed python-version from "3.9" to "3.12" on line 43 to fi

### DIFF
--- a/.github/workflows/ci-memory-test-phase2.yml
+++ b/.github/workflows/ci-memory-test-phase2.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python (deliberately wrong version)
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"    # BUG: X | Y union type syntax requires 3.10+
+          python-version: "3.12"    # BUG: X | Y union type syntax requires 3.10+
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## 🤖 HAL9000-OPS — Surgical Pipeline Fix

> **DRAFT — cannot be merged without manual review.**
> Only the lines directly responsible for the failure were changed.
> All workflow names, job names, step names, and structure are preserved exactly.

---

### What Failed
- **Workflow Run**: #22803501381
- **Branch**: `main`
- **Investigation**: https://github.com/retr0man99/hal9000-ops-target/issues/14

### What Changed
Changed python-version from "3.9" to "3.12" on line 43 to fix SyntaxError due to unsupported match statement

### Exact Diff
```diff
--- a/.github/workflows/ci-memory-test-phase2.yml+++ b/.github/workflows/ci-memory-test-phase2.yml@@ -40,7 +40,7 @@       - name: Set up Python (deliberately wrong version)
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"    # BUG: X | Y union type syntax requires 3.10+
+          python-version: "3.12"    # BUG: X | Y union type syntax requires 3.10+
 
       - name: Install dependencies
         run: |

```

### Agent Confidence
`HIGH`

### Review Checklist
- [ ] Only the broken lines are changed — nothing else
- [ ] Workflow name, job names, and step names are unchanged
- [ ] The fix addresses the root cause from the investigation issue
- [ ] No secrets or credentials introduced
- [ ] You have verified the fix locally or in a branch run

---
*Generated by [HAL9000-OPS](https://github.com/retr0man99/hal9000-ops) — surgical fixes only*
