### PR TITLE
[HAL9000-OPS] Changed python-version from 3.8 to 3.12 on line 39 to fix Sy

### DIFF
--- a/.github/workflows/ci-memory-test-phase1.yml
+++ b/.github/workflows/ci-memory-test-phase1.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python (deliberately wrong version)
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"    # BUG: match/case requires 3.10+
+          python-version: "3.12"    # BUG: match/case requires 3.10+
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## 🤖 HAL9000-OPS — Surgical Pipeline Fix

> **DRAFT — cannot be merged without manual review.**
> Only the lines directly responsible for the failure were changed.
> All workflow names, job names, step names, and structure are preserved exactly.

---

### What Failed
- **Workflow Run**: #22803512195
- **Branch**: `main`
- **Investigation**: https://github.com/retr0man99/hal9000-ops-target/issues/15

### What Changed
Changed python-version from 3.8 to 3.12 on line 39 to fix SyntaxError

### Exact Diff
```diff
--- a/.github/workflows/ci-memory-test-phase1.yml+++ b/.github/workflows/ci-memory-test-phase1.yml@@ -36,7 +36,7 @@       - name: Set up Python (deliberately wrong version)
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"    # BUG: match/case requires 3.10+
+          python-version: "3.12"    # BUG: match/case requires 3.10+
 
       - name: Install dependencies
         run: |

```

### Agent Confidence
`HIGH`

### Review Checklist
- [ ] Only the broken lines are changed — nothing else
- [ ] Workflow name, job names, and step names are unchanged
- [ ] The fix addresses the root cause from the investigation issue
- [ ] No secrets or credentials introduced
- [ ] You have verified the fix locally or in a branch run

---
*Generated by [HAL9000-OPS](https://github.com/retr0man99/hal9000-ops) — surgical fixes only*
