### PR TITLE
[HAL9000-OPS] Changed python-version from "3.9" to "3.12" on line 20 to fi

### DIFF
--- a/.github/workflows/ci-broken.yml
+++ b/.github/workflows/ci-broken.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## 🤖 HAL9000-OPS — Surgical Pipeline Fix

> **DRAFT — cannot be merged without manual review.**
> Only the lines directly responsible for the failure were changed.
> All workflow names, job names, step names, and structure are preserved exactly.

---

### What Failed
- **Workflow Run**: #22803559185
- **Branch**: `hal9000-ops/fix/22803501381-20260307-171926`
- **Investigation**: 

### What Changed
Changed python-version from "3.9" to "3.12" on line 20 to fix SyntaxError due to match/case usage

### Exact Diff
```diff
--- a/.github/workflows/ci-broken.yml+++ b/.github/workflows/ci-broken.yml@@ -18,7 +18,7 @@       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

```

### Agent Confidence
`HIGH`

### Review Checklist
- [ ] Only the broken lines are changed — nothing else
- [ ] Workflow name, job names, and step names are unchanged
- [ ] The fix addresses the root cause from the investigation issue
- [ ] No secrets or credentials introduced
- [ ] You have verified the fix locally or in a branch run

---
*Generated by [HAL9000-OPS](https://github.com/retr0man99/hal9000-ops) — surgical fixes only*
